### PR TITLE
Propagate error out up to file loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ use headscratcher::error::HeadScratcherError;
 
 fn main() -> Result<(), HeadScratcherError<String>>{
     let filename = "assets/sresa1b_ncar_ccsm3-example.nc".to_string();
-    let mut netcdf = NetCDF::new(filename);
+    let mut netcdf = NetCDF::new(filename)?;
     let mapsize = netcdf.mapsize()?;
 
     // allocate bytes for buffer (mapsize * external size)

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -3,7 +3,7 @@ use headscratcher::NetCDF;
 
 fn main() -> Result<(), HeadScratcherError<String>> {
     let filename = "assets/sresa1b_ncar_ccsm3-example.nc".to_string();
-    let mut netcdf = NetCDF::new(filename);
+    let mut netcdf = NetCDF::new(filename)?;
     let mapsize = netcdf.mapsize()?;
 
     // allocate bytes for buffer (mapsize * external size)

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ use nom::error::ErrorKind as NomErrorKind;
 pub enum HeadScratcherError<I> {
     /// Placeholder error
     EmptyError,
+    /// Invalid NetCDF file
+    InvalidFile,
     /// NetCDF version is not correct
     UnsupportedNetCDFVersion,
     /// Type of list is unknown
@@ -47,6 +49,27 @@ impl<I> nom::error::ParseError<I> for HeadScratcherError<I> {
 impl<I> From<std::io::Error> for HeadScratcherError<I> {
     fn from(err: std::io::Error) -> Self {
         HeadScratcherError::IOError(err.kind())
+    }
+}
+
+impl<I> HeadScratcherError<I> {
+    pub fn cast<T>(&self) -> Option<HeadScratcherError<T>> {
+        match &self {
+            HeadScratcherError::EmptyError => Some(HeadScratcherError::EmptyError),
+            HeadScratcherError::InvalidFile => Some(HeadScratcherError::InvalidFile),
+            HeadScratcherError::UnsupportedNetCDFVersion => Some(HeadScratcherError::UnsupportedNetCDFVersion),
+            HeadScratcherError::UnsupportedListType(list) => Some(HeadScratcherError::UnsupportedListType(*list)),
+            HeadScratcherError::NonZeroValue(val) => Some(HeadScratcherError::NonZeroValue(*val)),
+            HeadScratcherError::UnsupportedZeroListType => Some(HeadScratcherError::UnsupportedZeroListType),
+            HeadScratcherError::UTF8error => Some(HeadScratcherError::UTF8error),
+            HeadScratcherError::UnknownNetCDFType(tpe) => Some(HeadScratcherError::UnknownNetCDFType(*tpe)),
+            HeadScratcherError::NomError(_, _) => None,
+            HeadScratcherError::IOError(err) => Some(HeadScratcherError::IOError(err.clone())),
+            HeadScratcherError::NoVariablesInFile => Some(HeadScratcherError::NoVariablesInFile),
+            HeadScratcherError::NoDimensionsInFile => Some(HeadScratcherError::NoDimensionsInFile),
+            HeadScratcherError::VariableNotFound(var) => Some(HeadScratcherError::VariableNotFound(var.clone())),
+            HeadScratcherError::CouldNotFindDimension(dim) => Some(HeadScratcherError::CouldNotFindDimension(dim.clone())),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@ pub struct NetCDF<F: Seek + Read> {
 }
 
 impl<F: Seek + Read> NetCDF<F> {
-    pub fn new_from_file(mut file: F) -> Self {
-        let h = NetCDFHeader::from_file(&mut file).unwrap();
-        NetCDF { file, header: h }
+    pub fn new_from_file(mut file: F) -> Result<Self, HeadScratcherError<String>> {
+        let h = NetCDFHeader::from_file(&mut file)?;
+        Ok(NetCDF { file, header: h })
     }
 
     pub fn update_buffer(
@@ -95,13 +95,13 @@ impl<F: Seek + Read> NetCDF<F> {
 }
 
 impl NetCDF<File> {
-    pub fn new(filename: String) -> Self {
-        let mut fs = File::open(&filename).unwrap();
-        let h = NetCDFHeader::from_file(&mut fs).unwrap();
-        NetCDF {
+    pub fn new(filename: String) -> Result<Self, HeadScratcherError<String>> {
+        let mut fs = File::open(&filename)?;
+        let h = NetCDFHeader::from_file(&mut fs)?;
+        Ok(NetCDF {
             file: fs,
             header: h,
-        }
+        })
     }
 }
 
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_read_netcdf() {
         let filename = "assets/sresa1b_ncar_ccsm3-example.nc".to_string();
-        let mut netcdf = NetCDF::new(filename);
+        let mut netcdf = NetCDF::new(filename).unwrap();
         let mut buffer = vec![0u8; 4];
         netcdf
             .update_buffer("tas".to_string(), &vec![0, 0, 0], &mut buffer)


### PR DESCRIPTION
This propagates the error upwards out to the caller, where it previously panicked.

As I mentioned in the commit, this removes the nom input data from the buffer. If we kept it we did, we'd keep running into lifetime issues as the error (with the input) might now live longer than the input itself. Returning the failed input to the caller in general is also not very helpful as the caller can't really do much with it. I haven't so far seen the input actually being used for recovery, we just straight up fail on any issue, so I don't think this is a big issue.

I have experimented with mapping `HeadScratcherError<&[u8]>` to something like `HeadScratcherError<File>` upon returning from the entry functions, but I couldn't seem to get it right.

Is this acceptable? Can you think of a better solution?